### PR TITLE
fix usermod in systemd-guest-user.service

### DIFF
--- a/systemd/system/systemd-guest-user.service
+++ b/systemd/system/systemd-guest-user.service
@@ -9,7 +9,7 @@ RefuseManualStop=yes
 [Service]
 Type=oneshot
 ExecStart=/usr/sbin/bash -c 'id guest >& /dev/null || useradd guest'
-ExecStart=/usr/sbin/usermod -d /home/guest/
+ExecStart=/usr/sbin/usermod -d /home/guest/ guest
 ExecStart=/usr/sbin/passwd -d guest
 ExecStart=/usr/sbin/bash -c 'cp -a /usr/share/guest-configuration/. /home/guest'
 ExecStart=/usr/sbin/chown -R guest:users /home/guest


### PR DESCRIPTION
/usr/sbin/usermod -d /home/guest/

results in:

```
Usage: usermod [options] LOGIN

Options:
  -c, --comment COMMENT         new value of the GECOS field
  -d, --home HOME_DIR           new home directory for the user account
  -e, --expiredate EXPIRE_DATE  set account expiration date to EXPIRE_DATE
  -f, --inactive INACTIVE       set password inactive after expiration
                                to INACTIVE
  -g, --gid GROUP               force use GROUP as new primary group
```

there is the LOGIN parameter missing.

/usr/sbin/usermod -d /home/guest/ guest

All ExecStart commands after usermod are not executed.